### PR TITLE
Fixed bugs in maccheck and output

### DIFF
--- a/src/mpc/online.rs
+++ b/src/mpc/online.rs
@@ -158,11 +158,6 @@ pub mod protocol {
             panic!("MACCheck did not succeed!")
         }
 
-        if !maccheck(params, vec![y_angle.clone()], state) {
-            panic!("MACCheck did not succeed!")
-        }
-
-        // Broadcast my y_angle share
         let (y_share, _) = y_angle;
         state
             .facilitator
@@ -177,7 +172,14 @@ pub mod protocol {
             }
         }
 
-        open_shares(params, y_shares)
+        let y = open_shares(params, y_shares);
+
+        if !maccheck(params, vec![(y.clone(), y_angle.1)], state) {
+            panic!("MACCheck did not succeed!")
+        }
+
+        // Broadcast my y_angle share
+        return y
     }
 }
 
@@ -317,14 +319,14 @@ fn maccheck<F: Facilicator>(
         if let OnlineMessage::ShareCommitOpen(o_i) = msg {
             let opened = open(sigma_commitments[p_i].clone(), o_i).unwrap();
             sigma_is[p_i] = BigInt::from_bytes_be(
-                num::bigint::Sign::NoSign,
+                num::bigint::Sign::Plus,
                 opened
                     .iter()
                     .take(opened.len() - 32)
                     .cloned()
                     .collect::<Vec<u8>>()
                     .as_slice(),
-            )
+            );
         }
     }
 


### PR DESCRIPTION
First bug:
second maccheck call in online used incorrect input.


Second bug:
maccheck used incorrect num::bigint::Sign for conversion from bytes to BigInt, which resulted in always returning 0.